### PR TITLE
Fix for ruby 1.9.3 warnings

### DIFF
--- a/lib/methadone/main.rb
+++ b/lib/methadone/main.rb
@@ -1,6 +1,7 @@
 require 'optparse'
 
 if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('1.9')
+  Object.send(:remove_const, :BasicObject)
   BasicObject = Object
 end
 


### PR DESCRIPTION
I had some messages sent to stderr based on line 4 in main.rb when using ruby 1.9.3

methadone-0.3.4/lib/methadone/main.rb:4: warning: assigned but unused variable - basic_object

and also

warning: already initialized constant BasicObject

I think this patch may fix that? If the version number is greater equal to 1.9 replace BasicObject with Object. Is the intended functionality? I think this patch does this.
