### PR TITLE
Show help when ran with no arguments

### DIFF
--- a/lib/methadone/main.rb
+++ b/lib/methadone/main.rb
@@ -122,7 +122,10 @@ module Methadone
         exit 0
       end
     rescue OptionParser::ParseError => ex
+      puts
       error ex.message
+      puts
+      puts opts.help
       exit 64 # Linux standard for bad command line
     end
 


### PR DESCRIPTION
Methadone simply errors out when no `app_name` is supplied. Change to show error
and output help, then exit like normal.
