### PR TITLE
Specify pre version in methadone executable until 1.0.0 is released

### DIFF
--- a/bin/methadone
+++ b/bin/methadone
@@ -48,7 +48,7 @@ main do |app_name|
     "  #{gem_variable}.add_development_dependency('rdoc')",
     "  #{gem_variable}.add_development_dependency('aruba')",
     "  #{gem_variable}.add_development_dependency('rake','~> 0.9.2')",
-    "  #{gem_variable}.add_dependency('methadone', '~> 1.0.0.pre')",
+    "  #{gem_variable}.add_dependency('methadone', '~> 1.0.0pre')",
   ], :before => /^end\s*$/
 end
 


### PR DESCRIPTION
- Until 1.0.0 is released and to keep version 0.5.1 from being pulled in
  when running methadone command, specify the pre version.
- This should be reverted before release.

That way, don't have to modify the file manually after the gem is installed
