### PR TITLE
methadone should support exec of arrays

### DIFF
--- a/lib/methadone/execution_strategy/base.rb
+++ b/lib/methadone/execution_strategy/base.rb
@@ -3,11 +3,14 @@ module Methadone
     # Base for any ExecutionStrategy implementation.  Currently, this is nothing more than an interface
     # specification.
     class Base
-      # Executes the command and returns the results back.
-      # This should do no logging or other logic other than to execute the command
-      # and return the required results.
+      # Executes the command and returns the results back.  This
+      # should do no logging or other logic other than to execute the
+      # command and return the required results.  If command is an
+      # array, use exec directly bypassing any tokenization, shell or
+      # otherwise; otherwise use the normal shell interpretation of
+      # the command string.
       #
-      # command:: the command-line to run, as a String
+      # command:: the command-line to run, as an Array or a String
       #
       # Returns an array of size 3:
       # <tt>[0]</tt>:: The standard output of the command as a String, never nil

--- a/lib/methadone/execution_strategy/jvm.rb
+++ b/lib/methadone/execution_strategy/jvm.rb
@@ -5,7 +5,12 @@ module Methadone
     # Methadone::ExecutionStrategy for the JVM that uses JVM classes to run the command and get its results.
     class JVM < Base
       def run_command(command)
-        process = java.lang.Runtime.get_runtime.exec(command)
+        process = case command
+                  when String then
+                    java.lang.Runtime.get_runtime.exec(command)
+                  else
+                    java.lang.Runtime.get_runtime.exec(*command)
+                  end
         process.get_output_stream.close
         stdout = input_stream_to_string(process.get_input_stream)
         stderr = input_stream_to_string(process.get_error_stream)

--- a/lib/methadone/execution_strategy/open_3.rb
+++ b/lib/methadone/execution_strategy/open_3.rb
@@ -5,7 +5,10 @@ module Methadone
     # Implementation for modern Rubies that uses the built-in Open3 library
     class Open_3 < MRI
       def run_command(command)
-        stdout,stderr,status = Open3.capture3(command)
+        stdout,stderr,status = case command
+                               when String then Open3.capture3(command)
+                               else Open3.capture3(*command)
+                               end
         [stdout.chomp,stderr.chomp,status]
       end
     end

--- a/lib/methadone/execution_strategy/open_4.rb
+++ b/lib/methadone/execution_strategy/open_4.rb
@@ -6,7 +6,11 @@ module Methadone
     # Open4 to get access to the standard output AND error.
     class Open_4 < MRI
       def run_command(command)
-        pid, stdin_io, stdout_io, stderr_io = Open4::popen4(command)
+        pid, stdin_io, stdout_io, stderr_io =
+          case command
+          when String then Open4::popen4(command)
+          else Open4::popen4(*command)
+          end
         stdin_io.close
         stdout = stdout_io.read
         stderr = stderr_io.read

--- a/test/execution_strategy/test_open_3.rb
+++ b/test/execution_strategy/test_open_3.rb
@@ -29,6 +29,29 @@ module ExecutionStrategy
       }
     end
 
+    test_that "run_command handles array arguments properly" do
+      Given {
+        @command = [any_string, any_string, any_string]
+        @stdout = any_string
+        @stderr = any_string
+        @status = stub('Process::Status')
+      }
+      When the_test_runs
+      Then {
+        Open3.expects(:capture3).with(*@command).returns([@stdout,@stderr,@status])
+      }
+
+      Given new_open_3_strategy
+      When {
+        @results = @strategy.run_command(@command)
+      }
+      Then {
+        @results[0].should == @stdout
+        @results[1].should == @stderr
+        @results[2].should be @status
+      }
+    end
+
     test_that "exception_meaning_command_not_found returns Errno::ENOENT" do
       Given new_open_3_strategy
       When {


### PR DESCRIPTION
Kernel.exec of a string, and anything that calls that (open4, open3, or indirectly the JVM runtime execs) performs an additional layer of tokenization; usually this is done by the shell on Unix systems.  It is not difficult to create a difficult to escape string that, when passed to a shell, will cause some sort of security escalation; as a simple example imagine running

```
sh "rm #{file}"
```

where file could, say, be equal to "-rf /".

To avoid problems like these, this patch permits users to use exec with an array argument, which is supported by every execution strategy methadone supports.  This will not invoke the shell, and so in this case

```
sh "rm", file
```

would probably return "file '-rf /' not found".

This change should be backwards compatible.
