### PR TITLE
Nitpicky logging change.

### DIFF
--- a/lib/methadone/sh.rb
+++ b/lib/methadone/sh.rb
@@ -103,7 +103,7 @@ module Methadone
       stdout,stderr,status = execution_strategy.run_command(command)
       process_status = Methadone::ProcessStatus.new(status,options[:expected])
 
-      sh_logger.warn("Error output of '#{command}': #{stderr}") unless stderr.strip.length == 0
+      sh_logger.warn("stderr output of '#{command}': #{stderr}") unless stderr.strip.length == 0
 
       if process_status.success?
         sh_logger.debug("Output of '#{command}': #{stdout}") unless stdout.strip.length == 0


### PR DESCRIPTION
Replace "Error output of" with "stderr output of" to ensure that folks know there's not actually any error.

This was especially annoying when writing a wrapper around Hadoop components. They log everything to stderr, so I kept seeing "Error", even though everything was working fine.
