### PR TITLE
fix code that computes module_name

### DIFF
--- a/bin/methadone
+++ b/bin/methadone
@@ -16,7 +16,7 @@ main do |app_name|
   using_readme = options[:readme]
 
   gemname = File.basename(app_name)
-  module_name = gemname.split(/_/).map(&:capitalize).join('').split(/-/).map(&:capitalize).join("::")
+  module_name = gemname.split(/-/).map(&:capitalize).collect{ |segment| segment.split(/_/).map(&:capitalize).join('') }.join('::')
 
   debug "Creating project for gem #{gemname}"
 


### PR DESCRIPTION
Using methadone to create a new app with a name like `foo_bar_app`, the
old code would compute module_name to be `Foobarapp` when it should be
`FooBarApp`. This results in an error when trying to run the app
generated by methadone.  The app will crash with an error like:

``` bash
$ bundle exec bin/foo_bar_app 
bin/foo_bar_app:38:in `<class:App>': uninitialized constant
App::Foobarapp (NameError)
    from bin/foo_bar_app:7:in `<main>'
```

This code will properly compute the module_name.
