### PR TITLE
Added help_if_bare directive to print usage if command called with no options or arguments

### DIFF
--- a/lib/methadone/main.rb
+++ b/lib/methadone/main.rb
@@ -127,6 +127,11 @@ module Methadone
       @leak_exceptions = leak
     end
 
+    # Print the usage help if the command is run without any options or arguments.
+    def help_if_bare
+      @default_help = true
+    end
+
     # Set the name of the environment variable where users can place default
     # options for your app.  Omit this to disable the feature.
     def defaults_from_env_var(env_var)
@@ -156,6 +161,11 @@ module Methadone
     # If a required argument (see #arg) is not found, this exits with
     # 64 and a message about that missing argument.
     def go!
+      if @default_help and ARGV.empty?
+        puts opts.to_s
+        exit 64 # sysexits.h exit code EX_USAGE
+      end
+
       setup_defaults
       opts.post_setup
       opts.parse!

--- a/test/test_main.rb
+++ b/test/test_main.rb
@@ -738,6 +738,22 @@ class TestMain < BaseTest
     }
   end
 
+  test_that "usage is displayed if called with no arguments given when help_if_bare specified" do
+    Given {
+      help_if_bare
+      on("--required VALUE")
+      main {puts 'main called'}
+    }
+    When {
+      @code = lambda {go!}
+    }
+    Then {
+      assert_exits(64,&@code)
+      $stdout.string.should_not match /main called/
+      $stdout.string.should match /Usage:.*--required VALUE/m
+    }
+  end
+
 private
 
   def app_to_use_rc_file


### PR DESCRIPTION
Most of my command line utilities take subcommands or required options, and by default, I print the usage if only the bare command is executed.  This PR extracts this pattern into a directive for simple reuse.

I used the directive name 'help_if_bare' -- I'm open to changing this if you can think of a more concise and clear manner.  I had also toyed with 'default_help' and 'help_on_no_arguments', but to be honest, at this point they're all ceasing to be meaningful, in the same way that if you say the same word over and over again, it stops sounding like a word -- I could really use a second opinion.

Thanks for providing methadone -- it has made life much better for me.  I was just about to provide pull requests for a simpler version and not needing to put main at the top, but I see that you beat me to it with v1.3.0!