### PR TITLE
Added a helpful error message when you forget to set a logger.

### DIFF
--- a/lib/methadone/sh.rb
+++ b/lib/methadone/sh.rb
@@ -196,7 +196,10 @@ module Methadone
     end
 
     def sh_logger
-      @sh_logger ||= self.logger
+      @sh_logger ||= begin
+        raise StandardError, "No logger set! Please include Methadone::CLILogging or provide your own via #set_sh_logger." unless self.respond_to?(:logger)
+        self.logger
+      end
     end
 
     # Safely call our block, even if the user passed in a lambda

--- a/test/test_sh.rb
+++ b/test/test_sh.rb
@@ -261,8 +261,8 @@ class TestSH < Clean::Test::TestCase
 
   class MyTestApp
     include Methadone::SH
-    def initialize(logger)
-      set_sh_logger(logger)
+    def initialize(logger=nil)
+      set_sh_logger(logger) if logger
     end
   end
 
@@ -277,6 +277,19 @@ class TestSH < Clean::Test::TestCase
     }
     Then {
       assert_successful_command_execution(@exit_code,@logger,@command,test_command_stdout)
+    }
+  end
+
+  test_that "when we don't have CLILogging included and fail to provide a logger, an exception is thrown" do
+    Given {
+      @test_app = MyTestApp.new
+      @command = test_command
+    }
+    When {
+      @code = lambda { @test_app.sh @command }
+    }
+    Then {
+      exception = assert_raises(StandardError,&@code)
     }
   end
 


### PR DESCRIPTION
I was puzzled for a while at an unhelpful NoMethodError. I had forgotten to include `Methadone::CLILogging` nor provided my own logger.

This provides a helpful error message. I included a passing test.
