### PR TITLE
Updated to RSpec 3.0 with :should syntax

### DIFF
--- a/methadone.gemspec
+++ b/methadone.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("simplecov", "~> 0.5")
   s.add_development_dependency("clean_test")
   s.add_development_dependency("mocha", "0.13.2")
-  s.add_development_dependency("minitest", "4.6.1")
   s.add_development_dependency("sdoc")
-  s.add_development_dependency("rspec", "~> 2.99") # needed so that rspec-bootstrapped app test can run
+  s.add_development_dependency("rspec", "~> 3.0.0") # needed so that rspec-bootstrapped app test can run
 end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -2,10 +2,14 @@ require 'simplecov'
 SimpleCov.start do
   add_filter "/test"
 end
+
 require 'test/unit'
 require 'rspec/expectations'
 require 'clean_test/test_case'
 require 'ostruct'
 
+RSpec::Matchers.configuration.syntax = :should
+
 class BaseTest < Clean::Test::TestCase
+  include RSpec::Matchers
 end

--- a/test/test_sh.rb
+++ b/test/test_sh.rb
@@ -1,7 +1,7 @@
 require 'base_test'
 require 'methadone'
 
-class TestSH < Clean::Test::TestCase
+class TestSH < BaseTest
   include Methadone::SH
   include Methadone::CLILogging
 
@@ -143,7 +143,7 @@ class TestSH < Clean::Test::TestCase
       use_capturing_logger
       @command = test_command("foo")
       @block_called = false
-    } 
+    }
     When {
       @exit_code = sh @command do
         @block_called = true
@@ -160,7 +160,7 @@ class TestSH < Clean::Test::TestCase
       use_capturing_logger
       @command = test_command("foo")
       @block_called = false
-    } 
+    }
     When {
       @exit_code = sh @command, :expected => [2] do
         @block_called = true
@@ -180,7 +180,7 @@ class TestSH < Clean::Test::TestCase
           @command = test_command("foo")
           @block_called = false
           @exitstatus_received = nil
-        } 
+        }
         When {
           @exit_code = self.send(method,@command,:expected => expected) do |_,_,exitstatus|
             @block_called = true
@@ -242,7 +242,7 @@ class TestSH < Clean::Test::TestCase
     }
   end
 
-  test_that "sh! runs a command that will fail and includes an error message that appears in the exception" do 
+  test_that "sh! runs a command that will fail and includes an error message that appears in the exception" do
     Given {
       use_capturing_logger
       @command = test_command("foo")


### PR DESCRIPTION
It's pretty easy. :-)

Also removed unnecessary MiniTest gem (built into Ruby now) and resolved some deprecation warnings.

```
Finished tests in 0.634248s, 165.5504 tests/s, 105.6369 assertions/s.
105 tests, 67 assertions, 0 failures, 0 errors, 0 skips
```
