### PR TITLE
Fix personalization of the Apache license template

### DIFF
--- a/features/license.feature
+++ b/features/license.feature
@@ -29,6 +29,7 @@ Feature: Users should get the license included
 
     Examples:
       |license|
+      |apache|
       |mit|
       |gplv2|
       |gplv3|

--- a/templates/full/apache_LICENSE.txt.erb
+++ b/templates/full/apache_LICENSE.txt.erb
@@ -187,7 +187,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-      Copyright <%= Time.now.year %> <%=`git config.user` %>
+      Name: <%= gemspec.name %><%#TODO: Get program name more efficiently  -%>
+      Copyright <%= Time.now.year %> <%=`git config user.name` %>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix a typo in retrieving the username from git.
Add the Apache license to the cucumber scenario.

I  had made a typo introduced in my previous pull request. It only affected the Apache license template, which didn't use the shared personalization header (templates/full/_license_head.txt.erb). This caused a git error message when using the Apache license and the error went unnoticed by the cucumber test suite because the Apache license wasn't included in the personalization scenario.
