### PR TITLE
Remove rake from gemspec template

### DIFF
--- a/bin/methadone
+++ b/bin/methadone
@@ -79,7 +79,7 @@ main do |app_name|
   add_to_file gemspec, [
     "  #{gem_variable}.add_development_dependency('rdoc')",
     "  #{gem_variable}.add_development_dependency('aruba')",
-    "  #{gem_variable}.add_development_dependency('rake', '~> 0.9.2')",
+    "  #{gem_variable}.add_development_dependency('rake')",
     "  #{gem_variable}.add_dependency('methadone', '~> #{Methadone::VERSION}')",
   ], :before => /^end\s*$/
 

--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -36,7 +36,7 @@ Feature: Bootstrap a new command-line app
     And the file "tmp/newgem/.gitignore" should match /.DS_Store/
     And the file "tmp/newgem/newgem.gemspec" should match /add_development_dependency\('aruba'/
     And the file "tmp/newgem/newgem.gemspec" should match /add_development_dependency\('rdoc'/
-    And the file "tmp/newgem/newgem.gemspec" should match /add_development_dependency\('rake', '~> 0.9.2'/
+    And the file "tmp/newgem/newgem.gemspec" should match /add_development_dependency\('rake'/
     And the file "tmp/newgem/newgem.gemspec" should match /add_dependency\('methadone'/
     And the file "tmp/newgem/newgem.gemspec" should use the same block variable throughout
     Given I cd to "tmp/newgem"


### PR DESCRIPTION
`bundle gem` now includes `rake` on `gemspec` by default, so this is unnecessary.
https://github.com/bundler/bundler/blob/78a60bf8c671dd3905d7b775511f9b677cb16dda/lib/bundler/templates/newgem/newgem.gemspec.tt#L30
