### PR TITLE
Allow absolute config files (#87)

### DIFF
--- a/lib/methadone/main.rb
+++ b/lib/methadone/main.rb
@@ -133,14 +133,17 @@ module Methadone
       @env_var = env_var
     end
 
-    # Set the name of the file, in the user's home directory, where defaults can be configured.
+    # Set the path to the file where defaults can be configured.
+    #
     # The format of this file can be either a simple string of options, like what goes
     # in the environment variable (see #defaults_from_env_var), or YAML, in which case
     # it should be a hash where keys are the option names, and values their defaults.
     #
-    # filename:: name of the file, relative to the user's home directory
+    # Relative paths will be expanded relative to the user's home directory.
+    #
+    # filename:: path to the file
     def defaults_from_config_file(filename,options={})
-      @rc_file = File.join(ENV['HOME'],filename)
+      @rc_file = File.expand_path(filename, ENV['HOME'])
     end
 
     # Start your command-line app, exiting appropriately when

--- a/test/test_main.rb
+++ b/test/test_main.rb
@@ -652,6 +652,31 @@ class TestMain < BaseTest
 
   end
 
+  test_that "we can get defaults from an absolute config filename" do
+    tempfile = Tempfile.new('methadone_test.rc')
+    Given app_to_use_rc_file(tempfile)
+    And {
+      @flag_value = any_string
+      rc_file = File.join(tempfile)
+      File.open(rc_file,'w') do |file|
+        file.puts({
+          'switch' => true,
+          'flag' => @flag_value,
+        }.to_yaml)
+      end
+    }
+    When {
+      @code = lambda { go! }
+    }
+    Then {
+      assert_exits(0,&@code)
+      @switch.should == true
+      @flag.should == @flag_value
+    }
+
+  end
+
+
   test_that "we can specify an rc file even if it doesn't exist" do
     Given app_to_use_rc_file
     And {
@@ -740,7 +765,7 @@ class TestMain < BaseTest
 
 private
 
-  def app_to_use_rc_file
+  def app_to_use_rc_file(rc_file = '.my_app.rc')
     lambda {
       reset!
       @switch = nil
@@ -752,7 +777,7 @@ private
         @args = args
       end
 
-      defaults_from_config_file '.my_app.rc'
+      defaults_from_config_file rc_file
 
       on('--switch','Some Switch')
       on('--flag FOO','Some Flag')


### PR DESCRIPTION
Use File.expand_path instead of File.join in defaults_from_config_file
to allow absolute paths.

Relative paths will still be relative to HOME. Additionally, ~ expansion
is now also possible.

It seems reasonable to me that nobody will be using leading slashes for
their config filenames so far, so it should be safe to assume that when
they do, they want absolute paths.

However, to be safe you might want to consider this a API change.