### PR TITLE
Implement multi-level commands for git-like CLI

### DIFF
--- a/bin/methadone
+++ b/bin/methadone
@@ -22,6 +22,15 @@ main do |app_name|
 
   chdir File.dirname(app_name)
 
+  # Create the basic files for a gem via bundler:
+  #   Gemfile
+  #   Rakefile
+  #   LICENSE.txt
+  #   README.md
+  #   .gitignore
+  #   <gemname>.gemspec
+  #   lib/<gemname>.rb
+  #   lib/<gemname>/version.rb
   require_file = nil
   sh! "bundle gem #{gemname} --no-color" do |stdout|
     require_file = stdout.split(/\n/).select { |file|
@@ -31,9 +40,21 @@ main do |app_name|
   require_file = gemname if require_file.nil?
   require_file.gsub!(/^.*lib\//,'')
 
+  add_library_to_load_path = options[:add_lib] || false
+
   chdir gemname
 
   template_dirs_in(:full).each  { |dir| mkdir_p dir }
+
+  commands = options[:commands]
+  multi = !commands.nil?
+  if multi
+    mkdir_p "lib/#{gemname}/commands"
+    copy_file 'lib/commands.rb', :as => "#{gemname}/commands.rb", :from => :multicommand, :binding => binding
+    commands.each do |cmd|
+      copy_file 'lib/command.rb', :as => "#{gemname}/commands/#{normalize_command(cmd)}.rb",  :from => :multicommand, :binding => binding
+    end
+  end
 
   rspec = options[:rspec]
 
@@ -48,7 +69,6 @@ main do |app_name|
     template_dirs_in(:test_unit).each  { |dir| mkdir_p dir }
     copy_file "test/tc_something.rb", :from => :test_unit, :binding => binding
   end
-
 
   gemspec = "#{gemname}.gemspec"
   gem_variable = File.open(gemspec) { |x| x.read }.match(/(\w+)\.executables/)[1]
@@ -78,7 +98,7 @@ main do |app_name|
 
   copy_file "features/executable.feature", :as => "#{gemname}.feature", :binding => binding
   copy_file "features/step_definitions/executable_steps.rb", :as => "#{gemname}_steps.rb"
-  copy_file "bin/executable", :as => gemname, :executable => true, :binding => binding
+  copy_file "bin/executable", :as => gemname, :executable => true, :binding => binding, :from => (multi ? :multicommand : :full)
 
   add_to_file gemspec, [
     "  #{gem_variable}.add_development_dependency('rdoc')",
@@ -110,6 +130,16 @@ description "Kick the bash habit by bootstrapping your Ruby command-line apps"
 on("--force","Overwrite files if they exist")
 on("--[no-]readme","[Do not ]produce a README file")
 on("--rspec", "Generate RSpec unit tests instead of Test::Unit")
+on("--add-lib", "Add lib to the load path") do
+  options[:add_lib] = true
+end
+on "-c cmd1,cmd2,cmdN", "--commands", Array, "Generate framework for a cli app that provides the following commands" do |commands|
+  options[:commands] = commands
+  unless options[:commands].grep(/^-/).empty?
+    puts "Cannot have commands that begin with a '-'"
+    exit 65 # Data format error
+  end
+end
 
 licenses = %w(mit apache gplv2 gplv3 custom NONE)
 on("-l LICENSE","--license",licenses,"Specify the license for your project",'(' + licenses.join('|') + ')')

--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -7,7 +7,6 @@ Feature: Bootstrap a new command-line app
     Given the directory "tmp/newgem" does not exist
     And the directory "tmp/new-gem" does not exist
 
-    @wip
   Scenario: Bootstrap a new app from scratch
     When I successfully run `methadone tmp/newgem`
     Then the following directories should exist:
@@ -130,6 +129,23 @@ Feature: Bootstrap a new command-line app
     When I run `methadone`
     Then the exit status should not be 0
     And the stderr should match /'app_name' is required/
+
+  Scenario: We can add the lib directory to the load path
+    Given the directory "tmp/newgem2" does not exist
+    When I run `methadone --add-lib tmp/newgem2`
+    Then the exit status should be 0
+    And the file "tmp/newgem2/bin/newgem2" should match /\$LOAD_PATH\.unshift File\.expand_path\(File\.join\(File\.dirname\(__FILE__\), '\.\..lib'\)\)/
+
+    Given I cd to "tmp/newgem2"
+    And my app's name is "newgem2"
+    When I successfully run `bin/newgem2 --help`
+    Then the banner should be present
+    And the banner should document that this app takes options
+    And the following options should be documented:
+      |--version|
+      |--help|
+      |--log-level|
+    And the banner should document that this app takes no arguments
 
   Scenario: Help is properly documented
     When I get help for "methadone"

--- a/features/multilevel_commands.feature
+++ b/features/multilevel_commands.feature
@@ -1,0 +1,125 @@
+Feature: Support multi-level commands
+  As a developer who wants to make a multi-level command line app
+  I should be able to create a Methadone class that delegates subcommands to other Methadone classes
+  and each should support their own options, args and potentially other subcommands.
+
+  Background:
+    Given the directory "tmp/multigem" does not exist
+
+  Scenario: Bootstrap a multi-level app from scratch
+    When I successfully run `methadone --commands walk,run,crawl,dance tmp/multigem`
+    Then the following directories should exist:
+      |tmp/multigem                           |
+      |tmp/multigem/bin                       |
+      |tmp/multigem/lib                       |
+      |tmp/multigem/lib/multigem              |
+      |tmp/multigem/lib/multigem/commands     |
+      |tmp/multigem/test                      |
+      |tmp/multigem/features                  |
+      |tmp/multigem/features/support          |
+      |tmp/multigem/features/step_definitions |
+    Then the following directories should not exist:
+      |tmp/multigem/spec |
+    And the following files should exist:
+      |tmp/multigem/multigem.gemspec                            |
+      |tmp/multigem/Rakefile                                    |
+      |tmp/multigem/.gitignore                                  |
+      |tmp/multigem/Gemfile                                     |
+      |tmp/multigem/bin/multigem                                |
+      |tmp/multigem/lib/multigem/version.rb                     |
+      |tmp/multigem/lib/multigem/commands/walk.rb               |
+      |tmp/multigem/lib/multigem/commands/run.rb                |
+      |tmp/multigem/lib/multigem/commands/crawl.rb              |
+      |tmp/multigem/lib/multigem/commands/dance.rb              |
+      |tmp/multigem/features/multigem.feature                   |
+      |tmp/multigem/features/support/env.rb                     |
+      |tmp/multigem/features/step_definitions/multigem_steps.rb |
+      |tmp/multigem/test/tc_something.rb                        |
+    And the file "tmp/multigem/.gitignore" should match /results.html/
+    And the file "tmp/multigem/.gitignore" should match /html/
+    And the file "tmp/multigem/.gitignore" should match /pkg/
+    And the file "tmp/multigem/.gitignore" should match /.DS_Store/
+    And the file "tmp/multigem/multigem.gemspec" should match /add_development_dependency\('aruba'/
+    And the file "tmp/multigem/multigem.gemspec" should match /add_development_dependency\('rdoc'/
+    And the file "tmp/multigem/multigem.gemspec" should match /add_development_dependency "rake", "~> 10.0"/
+    And the file "tmp/multigem/multigem.gemspec" should match /add_dependency\('methadone'/
+    And the file "tmp/multigem/multigem.gemspec" should use the same block variable throughout
+    And the file "tmp/multigem/bin/multigem" should match /command "walk" => Multigem::Commands::Walk/
+    And the file "tmp/multigem/bin/multigem" should match /command "run" => Multigem::Commands::Run/
+    And the file "tmp/multigem/bin/multigem" should match /command "crawl" => Multigem::Commands::Crawl/
+    And the file "tmp/multigem/bin/multigem" should match /command "dance" => Multigem::Commands::Dance/
+    Given I cd to "tmp/multigem"
+    And my app's name is "multigem"
+    When I successfully run `bin/multigem --help` with "lib" in the library path
+    Then the banner should be present
+    And the banner should document that this app takes options
+    And the banner should document that this app takes commands
+    And the following commands should be documented:
+      |walk  |
+      |run   |
+      |crawl |
+      |dance |
+    And the following options should be documented:
+      |--version|
+      |--help|
+      |--log-level|
+
+  Scenario: Special characters in subcommands and gem name
+    Given a directory named "tmp"
+    And the directory "tmp/multigem2" does not exist
+    When I run `methadone --add-lib --commands walk,run,crawl_to_bed,tap-dance,@go-crazy tmp/multigem2`
+    Then the exit status should be 0
+    And the following directories should exist:
+      |tmp/multigem2                            |
+      |tmp/multigem2/bin                        |
+      |tmp/multigem2/lib                        |
+      |tmp/multigem2/lib/multigem2              |
+      |tmp/multigem2/lib/multigem2/commands     |
+      |tmp/multigem2/test                       |
+      |tmp/multigem2/features                   |
+      |tmp/multigem2/features/support           |
+      |tmp/multigem2/features/step_definitions  |
+    And the following directories should not exist:
+      |tmp/multigem2/spec |
+    And the following files should exist:
+      |tmp/multigem2/multigem2.gemspec                             |
+      |tmp/multigem2/Rakefile                                     |
+      |tmp/multigem2/.gitignore                                   |
+      |tmp/multigem2/Gemfile                                      |
+      |tmp/multigem2/bin/multigem2                                |
+      |tmp/multigem2/lib/multigem2/version.rb                     |
+      |tmp/multigem2/lib/multigem2/commands/walk.rb               |
+      |tmp/multigem2/lib/multigem2/commands/run.rb                |
+      |tmp/multigem2/lib/multigem2/commands/crawl_to_bed.rb       |
+      |tmp/multigem2/lib/multigem2/commands/tap_dance.rb          |
+      |tmp/multigem2/lib/multigem2/commands/go_crazy.rb           |
+      |tmp/multigem2/features/multigem2.feature                   |
+      |tmp/multigem2/features/support/env.rb                      |
+      |tmp/multigem2/features/step_definitions/multigem2_steps.rb |
+      |tmp/multigem2/test/tc_something.rb                         |
+    And the file "tmp/multigem2/bin/multigem2" should match /command "walk" => Multigem2::Commands::Walk/
+    And the file "tmp/multigem2/bin/multigem2" should match /command "run" => Multigem2::Commands::Run/
+    And the file "tmp/multigem2/bin/multigem2" should match /command "crawl_to_bed" => Multigem2::Commands::CrawlToBed/
+    And the file "tmp/multigem2/bin/multigem2" should match /command "tap-dance" => Multigem2::Commands::TapDance/
+    And the file "tmp/multigem2/bin/multigem2" should match /command "@go-crazy" => Multigem2::Commands::GoCrazy/
+    Given I cd to "tmp/multigem2"
+    And my app's name is "multigem2"
+    When I successfully run `bin/multigem2 --help`
+    Then the banner should be present
+    And the banner should document that this app takes options
+    And the banner should document that this app takes commands
+    And the following commands should be documented:
+      |walk         |
+      |run          |
+      |crawl_to_bed |
+      |tap-dance    |
+      |@go-crazy    |
+    And the following options should be documented:
+      |--version|
+      |--help|
+      |--log-level|
+    When I successfully run `bin/multigem2 tap-dance -h`
+    Then the banner should be present
+    And the banner should document that this app takes global options
+    And the banner should document that this app takes options
+

--- a/lib/methadone/cli_logging.rb
+++ b/lib/methadone/cli_logging.rb
@@ -103,7 +103,7 @@ module Methadone
     def use_log_level_option(args = {})
       on("--log-level LEVEL",LOG_LEVELS,'Set the logging level',
                                         '(' + LOG_LEVELS.keys.join('|') + ')',
-                                        '(Default: info)') do |level|
+                                        '(Default: info)', :global) do |level|
         @log_level = level
         @log_level_original = level
         @log_level_toggled = false

--- a/lib/methadone/main.rb
+++ b/lib/methadone/main.rb
@@ -21,22 +21,22 @@ module Methadone
   # You also get a more expedient interface to OptionParser as well
   # as checking for required arguments to your app.  For example, if
   # we want our app to accept a negatable switch named "switch", a flag
-  # named "flag", and two arguments "needed" (which is required) 
+  # named "flag", and two arguments "needed" (which is required)
   # and "maybe" which is optional, we can do the following:
   #
   #     #!/usr/bin/env ruby
-  #       
+  #
   #     require 'methadone'
-  #      
+  #
   #     class App
   #       include Methadone::Main
   #       include Methadone::CLILogging
-  #       
+  #
   #       main do |needed, maybe|
   #         options[:switch] => true or false, based on command line
   #         options[:flag] => value of flag passed on command line
   #       end
-  #       
+  #
   #       # Proxy to an OptionParser instance's on method
   #       on("--[no]-switch")
   #       on("--flag VALUE")
@@ -52,7 +52,7 @@ module Methadone
   #
   # Our app then acts as follows:
   #
-  #     $ our_app 
+  #     $ our_app
   #     # => parse error: 'needed' is required
   #     $ our_app foo
   #     # => succeeds; "maybe" in main is nil
@@ -70,6 +70,51 @@ module Methadone
   # present on *every* object.  This can cause odd problems, so it's recommended that you
   # *not* do this.
   #
+  # Subcommands
+  # -----------
+  #
+  # In order to promote modularity and maintainability, complex command line
+  # applications should be broken up into subcommands.  Subcommands are just
+  # like regular Methadone applications, except you don't put a go! call in it.
+  # It will be run in by the base methadone app class.  Likewise, subcommands
+  # can have subcommands of their own.
+  #
+  # In order to tell a Methadone app class that it has subcommands, use the
+  # command method, which takes a hash with the command name as a key and the
+  # command class as the value.  Multiple subcommands can be specified in a
+  # single call, or as separate calls.
+  #
+  #     #!/usr/bin/env ruby
+  #
+  #     require 'methadone'
+  #
+  #     class MySubcommand
+  #       include Methadone::Main
+  #       include Methadone::CLILogging
+  #
+  #       on '-f','--foo BAR', 'Some option'
+  #       arg 'something', :required, "Description","defaults: value"
+  #
+  #       main do |something|
+  #        # stuff
+  #       end
+  #     end
+  #
+  #     class App
+  #       include Methadone::Main
+  #       include Methadone::CLILogging
+  #
+  #       command "do" => MySubcommand
+  #
+  #       go!
+  #     end
+  #
+  # Apps that have subcommands (currently) don't support arguments and don't
+  # need to supply a main, as it doesn't get called.  This may change in a
+  # future version of Methadone.  Options to the app can modify the +options+
+  # contents will impactful to the subcommand as it receives those option
+  # values as the base for its options.
+  #
   module Main
     include Methadone::ExitNow
     include Methadone::ARGVParser
@@ -81,7 +126,7 @@ module Methadone
     # Declare the main method for your app.
     # This allows you to specify the general logic of your
     # app at the top of your bin file, but can rely on any methods
-    # or other code that you define later.  
+    # or other code that you define later.
     #
     # For example, suppose you want to process a set of files, but
     # wish to determine that list from another method to keep your
@@ -108,10 +153,10 @@ module Methadone
     # The block can accept any parameters, and unparsed arguments
     # from the command line will be passed.
     #
-    # *Note*: #go! will modify +ARGV+ so any unparsed arguments that you do *not* declare as arguments
-    # to #main will essentially be unavailable.  I consider this a bug, and it should be changed/fixed in
-    # a future version.
-    # 
+    # *Note*: #go! will modify +ARGV+ to remove any known options and
+    # arguments.  If there are any values left over, they will remain available
+    # in +ARGV+.
+    #
     # To run this method, call #go!
     def main(&block)
       @main_block = block
@@ -120,11 +165,22 @@ module Methadone
     # Configure the auto-handling of StandardError exceptions caught
     # from calling go!.
     #
-    # leak:: if true, go! will *not* catch StandardError exceptions, but instead
-    #        allow them to bubble up.  If false, they will be caught and handled as normal.
-    #        This does *not* affect Methadone::Error exceptions; those will NOT leak through.
+    # leak:: if true, go! will *not* catch StandardError exceptions, but
+    #        instead allow them to bubble up.  If false, they will be caught
+    #        and handled as normal.  This does *not* affect Methadone::Error
+    #        exceptions; those will NOT leak through.
+    #
+    #        leak_exceptions only needs to be set once; since it is stored as a
+    #        class variable, all classes that include this module will handle
+    #        exceptions the same way.
     def leak_exceptions(leak)
-      @leak_exceptions = leak
+      @@leak_exceptions = leak
+    end
+
+    # Print the usage help if the command is run without any options or
+    # arguments.
+    def help_if_bare
+      @default_help = true
     end
 
     # Set the name of the environment variable where users can place default
@@ -159,12 +215,37 @@ module Methadone
     #
     # If a required argument (see #arg) is not found, this exits with
     # 64 and a message about that missing argument.
-    def go!
+    #
+    def go!(parent=nil)
+      if @default_help and ARGV.empty?
+        puts opts.to_s
+        exit 64 # sysexits.h exit code EX_USAGE
+      end
+
+      # Get stuff from parent, if there
+      set_parent(parent)
+
       setup_defaults
       opts.post_setup
-      opts.parse!
-      opts.check_args!
-      result = call_main
+
+      if opts.commands.empty?
+        opts.parse!
+        opts.check_args!
+        opts.check_option_usage!
+        result = call_main
+      else
+        opts.parse_to_command! # Leaves unknown args and options in once it encounters a non-option.
+        opts.check_option_usage!
+        if opts.selected_command
+          result = call_provider
+        else
+          logger.error "You must specify a command"
+          puts ""
+          puts opts.help
+          exit 64
+        end
+      end
+
       if result.kind_of? Fixnum
         exit result
       else
@@ -193,13 +274,13 @@ module Methadone
     #       options[:flag] = value
     #     end
     #
-    # Since, most of the time, this is all you want to do,
-    # this makes it more expedient to do so.  The key that is
-    # is set in #options will be a symbol <i>and string</i> of the option name, without
-    # the leading dashes.  Note that if you use multiple option names, a key
-    # will be generated for each.  Further, if you use the negatable form,
-    # only the positive key will be set, e.g. for <tt>--[no-]verbose</tt>,
-    # only <tt>:verbose</tt> will be set (to true or false).
+    # Since, most of the time, this is all you want to do, this makes it more
+    # expedient to do so.  The key that is is set in #options will be a symbol
+    # <i>and string</i> of the option name, without the leading dashes.  Note
+    # that if you use multiple option names, a key will be generated for each.
+    # Further, if you use the negatable form, only the positive key will be set,
+    # e.g. for <tt>--[no-]verbose</tt>, only <tt>:verbose</tt> will be set (to
+    # true or false).
     #
     # As an example, this declaration:
     #
@@ -216,6 +297,31 @@ module Methadone
     # * <tt>options[:flag]</tt>
     #
     # Further, any one of those keys can be used to determine the default value for the option.
+    #
+    # Playing well with others
+    # ------------------------
+    #
+    # Sometimes you need the user to specify groups of options, or sometimes
+    # one option cannot be used in conjunction with another option.  While
+    # OptionParser does not natively support this, options defined with
+    # Methadone's +on+ method does so by using the following hash arguments:
+    #
+    #   :excludes => <optID>
+    #   :requires => <optID>
+    #
+    # The optID can be any of the keys that an option would create in the
+    # options hash.  You can even specify multiple options by using an array of
+    # optIDs:
+    #
+    #   :excludes => [:f, "another-option"]
+    #
+    # If you specify both an option and another option that excludes that
+    # option, an error is logged.  Only one side of an exclusion needs to be
+    # specified.
+    #
+    # If you use an option, but do not use an option it requires, an error will
+    # be logged.  Order of the options do not matter.
+    #
     def opts
       @option_parser ||= OptionParserProxy.new(OptionParser.new,options)
     end
@@ -226,12 +332,14 @@ module Methadone
       opts.on(*args,&block)
     end
 
-    # Sets the name of an arguments your app accepts.  Note
-    # that no sanity checking is done on the configuration
-    # of your arguments you create via multiple calls to this method.
-    # Namely, the last argument should be the only one that is
-    # a :many or a :any, but the system here won't sanity check that.
-    #
+    # Calls the +command+ method of #opts with the given arguments (see RDoc
+    # for #opts for the additional help provided).  Commands are special args
+    # that take their own options and other arguments.
+    def command(*args)
+      opts.command(*args)
+    end
+
+    # Sets the name of an arguments your app accepts.
     # +arg_name+:: name of the argument to appear in documentation
     #              This will be converted into a String and used to create
     #              the banner (unless you have overridden the banner)
@@ -241,14 +349,30 @@ module Methadone
     #             <tt>:one</tt>:: only one of this arg should be supplied (default)
     #             <tt>:many</tt>::  many of this arg may be supplied, but at least one is required
     #             <tt>:any</tt>:: any number, include zero, may be supplied
-    #             A string:: if present, this will be documentation for the argument and appear in the help
+    #             A string:: if present, this will be documentation for the
+    #                        argument and appear in the help.  Multiple strings will be
+    #                        listed on multiple lines
+    #             A Regexp:: Argument values must match the regexp, or an error will be raised.
+    #             An Array:: Argument values must be found in the array, or an error will be raised.
+    #
+    #  As of version 2.0, best effort is made to ensure values are assigned to
+    #  your arguments as needed.  :required and :many options will take one
+    #  value if possible, and the first greedy argument (:many or :any) will
+    #  consume any unallocated count of values remaining in ARGV.  Value
+    #  assignment still goes left to right, but allocation counts are determined
+    #  by needs of each argument.  Filtering rules do not play a part in
+    #  determining if a value can be allocated to an argument.
+    #
+    #  Greedy arguments that do not receive any values will hold an empty
+    #  array, while non-greedy arguments that do not receive a value will be
+    #  nil.
     def arg(arg_name,*options)
       opts.arg(arg_name,*options)
     end
 
     # Set the description of your app for inclusion in the help output.
     # +desc+:: a short, one-line description of your app
-    def description(desc)
+    def description(desc=nil)
       opts.description(desc)
     end
 
@@ -277,6 +401,12 @@ module Methadone
       @options ||= {}
     end
 
+    def global_options
+      (@parent.nil? ? {} : @parent.global_options).merge(
+        opts.global_options
+      )
+    end
+
     # Set the version of your app so it appears in the
     # banner.  This also adds --version as an option to your app which,
     # when used, will act just like --help (see version_options to control this)
@@ -294,12 +424,30 @@ module Methadone
     #                            two options: the first is the CLI app name, and the second is the version string
     def version(version,version_options={})
       opts.version(version)
+      if version_options.kind_of?(Symbol)
+        case version_options
+        when :terse
+          version_options = {
+            :custom_docs => "Show version",
+            :format => '%0.0s%s',
+            :compact => true
+          }
+        when :basic
+          version_options = {
+            :custom_docs => "Show version info",
+            :compact => true
+          }
+        else
+          version_options = version_options.to_s
+        end
+      end
+
       if version_options.kind_of?(String)
         version_options = { :custom_docs => version_options }
       end
       version_options[:custom_docs] ||= "Show help/version info"
       version_options[:format] ||= "%s version %s"
-      opts.on("--version",version_options[:custom_docs]) do 
+      opts.on("--version",version_options[:custom_docs]) do
         if version_options[:compact]
           puts version_options[:format] % [::File.basename($0),version]
         else
@@ -324,7 +472,19 @@ module Methadone
       set_defaults_from_env_var
     end
 
+    def set_parent(parent)
+      @parent = parent
+      if parent
+        @options.merge!(parent.global_options)
+        opts.extend_help_from_parent(parent.opts)
+      end
+    end
+
     def add_defaults_to_docs
+
+      # Remove any pre-existing separator text
+      opts.top.list.reject! {|v| v.is_a? String}
+
       if @env_var && @rc_file
         opts.separator ''
         opts.separator 'Default values can be placed in:'
@@ -352,7 +512,7 @@ module Methadone
 
     def set_defaults_from_rc_file
       if @rc_file && File.exists?(@rc_file)
-        File.open(@rc_file) do |file| 
+        File.open(@rc_file) do |file|
           parsed = YAML::load(file)
           if parsed.kind_of? String
             parse_string_for_argv(parsed).each do |arg|
@@ -387,7 +547,9 @@ module Methadone
 
     # Handle calling main and trapping any exceptions thrown
     def call_main
-      @main_block.call(*ARGV)
+      # Backwards compatibility ensured by adding ::ARGV
+      # TBD: rework spec so that unspecified args need to be retrieved from ARGV directly and not just passed into main
+      @main_block.call(*(opts.args_for_main))
     rescue Methadone::Error => ex
       raise ex if ENV['DEBUG']
       logger.error ex.message unless no_message? ex
@@ -396,7 +558,7 @@ module Methadone
       raise
     rescue => ex
       raise ex if ENV['DEBUG']
-      raise ex if @leak_exceptions
+      raise ex if @@leak_exceptions
       logger.error ex.message unless no_message? ex
       70 # Linux sysexit code for internal software error
     end
@@ -404,13 +566,18 @@ module Methadone
     def no_message?(exception)
       exception.message.nil? || exception.message.strip.empty?
     end
+
+    def call_provider
+      command = opts.selected_command
+      opts.commands[command].send(:go!,self)
+    end
   end
 
   # <b>Methadone Internal - treat as private</b>
   #
   # A proxy to OptionParser that intercepts #on
   # so that we can allow a simpler interface
-  class OptionParserProxy < BasicObject
+  class OptionParserProxy < Object
     # Create the proxy
     #
     # +option_parser+:: An OptionParser instance
@@ -420,27 +587,119 @@ module Methadone
     def initialize(option_parser,options)
       @option_parser = option_parser
       @options = options
+      @option_defs ||= {:local => [],:global => []}
+      @option_sigs = {}
+      @options_used = []
+      @usage_rules = {}
+      @commands = {}
+      @selected_command = nil
       @user_specified_banner = false
       @accept_options = false
       @args = []
       @arg_options = {}
+      @arg_filters = {}
       @arg_documentation = {}
+      @args_by_name = {}
       @description = nil
       @version = nil
-      set_banner
+      @banner_stale = true
       document_help
     end
 
+    def parent_opts=(parent_opts)
+      @parent_opts = parent_opts
+    end
+
+    def parent_opts
+      @parent_opts || nil
+    end
+
+    def global_options
+      global_option_defs = @option_defs.fetch(:global, nil)
+      return {} if global_option_defs.nil?
+
+      keys = global_option_defs.map {|opt_def|
+        [opt_def.long, opt_def.short].
+          flatten.
+          map {|flag| flag.sub(/^--?(\[no-\])?/,'')}.
+          map {|flag| [flag,flag.to_sym]}
+      }.flatten
+      global_hash = @options.select {|k,v| keys.include? k}
+      global_hash.is_a?(Array) ? Hash[global_hash] : global_hash # Stupid 1.8.7 => 1.9.3 API change of Hash#select
+    end
+
     def check_args!
-      ::Hash[@args.zip(::ARGV)].each do |arg_name,arg_value|
-        if @arg_options[arg_name].include? :required
-          if arg_value.nil?
-            message = "'#{arg_name.to_s}' is required"
-            message = "at least one " + message if @arg_options[arg_name].include? :many
-            raise ::OptionParser::ParseError,message
+      arg_allocation_map = @args.map {|arg_name| @arg_options[arg_name].include?(:required) ? 1 : 0}
+
+      arg_count = ::ARGV.length - arg_allocation_map.reduce(0,&:+)
+      if arg_count > 0
+        @args.each.with_index do |arg_name,i|
+          if (@arg_options[arg_name] & [:many,:any]).length > 0
+            arg_allocation_map[i] += arg_count
+            break
+          elsif @arg_options[arg_name].include? :optional
+            arg_allocation_map[i] += 1
+            arg_count -= 1
+            break if arg_count == 0
           end
         end
       end
+
+      @args.zip(arg_allocation_map).each do |arg_name,arg_count|
+        if not (@arg_options[arg_name] & [:many,:any]).empty?
+          arg_value = ::ARGV.shift(arg_count)
+        else
+          arg_value = (arg_count == 1) ? ::ARGV.shift : nil
+        end
+
+        if @arg_options[arg_name].include? :required and arg_value.nil?
+          message = "'#{arg_name.to_s}' is required"
+          raise ::OptionParser::ParseError,message
+        elsif @arg_options[arg_name].include?(:many) and arg_value.empty?
+          message = "at least one '#{arg_name.to_s}' is required"
+          raise ::OptionParser::ParseError,message
+        end
+
+        unless arg_value.nil? or arg_value.empty? or @arg_filters[arg_name].empty?
+          match = false
+          msg = ''
+          @arg_filters[arg_name].each do |filter|
+            if not (@arg_options[arg_name] & [:many,:any]).empty?
+              if filter.respond_to? :include?
+                invalid_values = (filter | arg_value) - filter
+              elsif filter.is_a? ::Regexp
+                invalid_values = arg_value - arg_value.grep(filter)
+              end
+              if invalid_values.empty?
+                match = true
+                break
+              end
+              msg = "The following value(s) were invalid: '#{invalid_values.join(' ')}'"
+            else
+              if filter.respond_to? :include?
+                if filter.include? arg_value
+                  match = true
+                  break
+                end
+              elsif filter.is_a?(::Regexp)
+                if arg_value =~ filter
+                  match = true
+                  break
+                end
+              end
+              msg = "'#{arg_value}' is invalid"
+            end
+          end
+
+          raise ::OptionParser::ParseError, "#{arg_name}: #{msg}" unless match
+
+        end
+        @args_by_name[arg_name] = arg_value
+      end
+    end
+
+    def args_for_main
+      @args.map {|name| @args_by_name[name]}
     end
 
     # If invoked as with OptionParser, behaves the exact same way.
@@ -448,21 +707,83 @@ module Methadone
     # to the constructor will be used to store
     # the parsed command-line value.  See #opts in the Main module
     # for how that works.
+    # Returns reference to the option for exclusive and mutual
     def on(*args,&block)
-      @accept_options = true
+
+      # Group together any of the hash arguments
+      (hashes, args) = args.partition {|a| a.respond_to?(:keys)}
+      on_opts = hashes.reduce({}) {|h1,h2| h1.merge(h2)}
+
+      scope = args.delete(:global) || :local
       args = add_default_value_to_docstring(*args)
-      if block
-        @option_parser.on(*args,&block)
-      else
-        opt_names = option_names(*args)
-        @option_parser.on(*args) do |value|
-          opt_names.each do |name| 
-            @options[name] = value 
-            @options[name.to_s] = value 
-          end
+      sig = option_signature(args)
+      opt_names = option_names(*args)
+
+      opt_names.each do |name|
+        @option_sigs[name] = sig
+      end
+
+      block ||= Proc.new do |value|
+        opt_names.each do |name|
+          @options[name] = value
         end
       end
-      set_banner
+      wrapper = Proc.new do |value|
+        register_usage opt_names
+        block.call(value)
+      end
+
+      opt = @option_parser.define(*args,&wrapper)
+      @option_defs[scope] << opt
+
+      set_usage_rules_for(opt_names,on_opts)
+
+      @accept_options = true
+      @banner_stale = true
+    end
+
+    def set_usage_rules_for(names,rules_source)
+      rule_keys = [:excludes, :requires]
+      rules = Hash[rule_keys.zip(rules_source.values_at(*rule_keys))].reject{|k,v| v.nil?}
+      return if rules.empty?
+
+      names.each do |name|
+        @usage_rules[name] = rules
+      end
+    end
+
+    def register_usage(opt_names)
+      opt_names.each do |name|
+        @options_used << name
+      end
+    end
+
+    def check_option_usage!
+      requirers = @options_used.select {|name| @usage_rules.fetch(name,{}).key?(:requires)}
+      requirers.each do |name|
+        required = [@usage_rules[name][:requires]].flatten
+        violation = required - @options_used
+        unless violation.empty?
+          raise OptionParser::OptionConflict.new("Missing option #{@option_sigs[violation.first]} required by option #{@option_sigs[name]}")
+        end
+      end
+      excluders = @options_used.select {|name| @usage_rules.fetch(name,{}).key?(:excludes)}
+      excluders.each do |name|
+        excluded = [@usage_rules[name][:excludes]].flatten
+        violation = (excluded & @options_used)
+        unless violation.empty?
+          raise OptionParser::OptionConflict, "#{@option_sigs[name]} cannot be used if already using #{@option_sigs[violation.first]}"
+        end
+      end
+    end
+
+    # Specify an acceptable command that will be hanlded by the given command provider
+    def command(provider_hash={})
+      provider_hash.each do |name,cls|
+        raise InvalidProvider.new("Provider for #{name} must respond to go!") unless cls.respond_to? :go!
+        commands[name.to_s] = cls
+      end
+      @banner_stale = true
     end
 
     # Proxies to underlying OptionParser
@@ -478,60 +799,164 @@ module Methadone
       options << :one unless options.include?(:any) || options.include?(:many)
       @args << arg_name
       @arg_options[arg_name] = options
-      options.select(&STRINGS_ONLY).each do |doc|
-        @arg_documentation[arg_name] = doc + (options.include?(:optional) ? " (optional)" : "")
-      end
-      set_banner
+      @arg_documentation[arg_name]= options.select(&STRINGS_ONLY)
+      @arg_filters[arg_name] = options.select {|o| o.is_a?(Array) or o.is_a?(Range) or o.is_a?(::Regexp)}
+      @banner_stale = true
     end
 
     def description(desc)
-      @description = desc
-      set_banner
+
+      @description = desc if desc
+      @banner_stale = true
+      @description
     end
 
-    # Defers all calls save #on to 
+    # Defers all calls save #on to
     # the underlying OptionParser instance
     def method_missing(sym,*args,&block)
       @option_parser.send(sym,*args,&block)
     end
 
+    def banner
+      set_banner if @banner_stale
+      @option_parser.banner
+    end
+
+    def help
+      set_banner if @banner_stale
+      @option_parser.to_s
+    end
+
     # Since we extend Object on 1.8.x, to_s is defined and thus not proxied by method_missing
     def to_s #::nodoc::
-      @option_parser.to_s
+      help
+    end
+
+
+    # Acess the command provider list
+    def commands
+      @commands
+    end
+
+    def parse_to_command!
+      @option_parser.order!
+      if command_names.include? ::ARGV[0]
+        @selected_command = ::ARGV.shift
+      end
+    end
+
+    # The selected command
+    def selected_command
+      @selected_command
     end
 
     # Sets the version for the banner
     def version(version)
       @version = version
-      set_banner
+      @banner_stale = true
+    end
+
+    # List the command names
+    def command_names
+      @command_names ||= commands.keys.map {|k| k.to_s}
     end
 
     # We need some documentation to appear at the end, after all OptionParser setup
     # has occured, but before we actually start.  This method serves that purpose
     def post_setup
-      unless @arg_documentation.empty?
+      if parent_opts and not (global_opts = parent_opts.global_options_help).empty?
+        @option_parser.separator ''
+        global_opts.split("\n").each {|line| @option_parser.separator line}
+      end
+
+      if @commands.empty? and ! @arg_documentation.empty?
         @option_parser.separator ''
         @option_parser.separator "Arguments:"
-        @option_parser.separator ''
         @args.each do |arg|
-          @option_parser.separator "    #{arg}"
-          @option_parser.separator "        #{@arg_documentation[arg]}"
+          option_tag = @arg_options[arg].include?(:optional) ? ' (optional)' : ''
+          @option_parser.separator "    #{arg}#{option_tag}"
+          @arg_documentation[arg].each do |doc|
+            @option_parser.separator "        #{doc}"
+          end
         end
       end
+
+      unless @commands.empty?
+        padding = @commands.keys.map {|name| name.to_s.length}.max + 1
+        @option_parser.separator ''
+        @option_parser.separator "Commands:"
+        @commands.each do |name,provider|
+          @option_parser.separator "  #{ "%-#{padding}s" % (name.to_s+':')} #{provider.description}"
+        end
+      end
+      @option_parser.separator ''
     end
 
-    private
+    def extend_help_from_parent(parent_opts)
+      self.parent_opts = parent_opts
+      @banner_stale = true
+    end
+
+  protected
+
+    def base_usage_line
+      line = parent_opts.nil? ? "\nUsage:" : parent_opts.base_usage_line
+      cmd = parent_opts && parent_opts.selected_command
+      line += ' ' + (cmd || ::File.basename($0)).to_s
+      if selected_command && accept_global_options?
+        if parent_opts
+          line += " [options for #{cmd}]"
+        else
+          line += " [global options]"
+        end
+      end
+      line
+    end
+
+    def global_options_help
+      msg = []
+      global_option_defs = @option_defs.fetch(:global,[])
+      unless global_option_defs.empty?
+        cmd = parent_opts && parent_opts.selected_command
+        opt_lines = [cmd.nil? ? "Global options:\n" : "Options for #{cmd}:\n"]
+        width = @option_parser.summary_width
+        indent = @option_parser.summary_indent
+        global_option_defs.each do |opt|
+          opt.summarize({},{},width,width - 1,indent) do |line|
+            opt_lines << (line.index($/, -1) ? line : line + $/)
+          end
+        end
+        msg << opt_lines.join('')
+      end
+      msg << parent_opts.global_options_help if parent_opts
+      msg.join ("\n")
+    end
+
+    def accept_global_options?
+      ! @option_defs.fetch(:global,[]).empty?
+    end
+
+  private
+
+    # Because there is always an option for -h, if there are subcommands, they
+    # need to show the option holder and Options prefix to differentiate
+    # between the command option an previous options.
+    def accept_options?
+      @accept_options
+    end
 
     def document_help
-      @option_parser.on("-h","--help","Show command line help") do 
-        puts @option_parser.to_s
+      @option_parser.on("-h","--help","Show command line help") do
+        puts self.to_s
         exit 0
       end
+      @banner_stale = true
     end
 
     def add_default_value_to_docstring(*args)
       default_value = nil
       option_names_from(args).each do |option|
+        option = option.sub(/\A\[no-\]/,'')
         default_value = (@options[option.to_s] || @options[option.to_sym]) if default_value.nil?
       end
       if default_value.nil?
@@ -542,37 +967,47 @@ module Methadone
     end
 
     def option_names_from(args)
-      args.select(&STRINGS_ONLY).select { |_| 
-        _ =~ /^\-/ 
-      }.map { |_| 
-        _.gsub(/^\-+/,'').gsub(/\s.*$/,'') 
+      args.select(&STRINGS_ONLY).select { |_|
+        _ =~ /^\-/
+      }.map { |_|
+        _.gsub(/^\-+/,'').gsub(/\s.*$/,'')
       }
     end
 
-    def set_banner
-      unless @user_specified_banner
-        new_banner="Usage: #{::File.basename($0)}"
-        new_banner += " [options]" if @accept_options
-        unless @args.empty?
-          new_banner += " " 
-          new_banner += @args.map { |arg|
-            if @arg_options[arg].include? :any
-              "[#{arg.to_s}...]"
-            elsif @arg_options[arg].include? :optional
-              "[#{arg.to_s}]"
-            elsif @arg_options[arg].include? :many
-              "#{arg.to_s}..."
-            else
-              arg.to_s
-            end
-          }.join(' ')
-        end
-        new_banner += "\n\n#{@description}" if @description
-        new_banner += "\n\nv#{@version}" if @version
-        new_banner += "\n\nOptions:" if @accept_options
+    def option_signature(args)
+      args.select(&STRINGS_ONLY).select {|s| s =~ /\A-/}.join('|')
+    end
 
-        @option_parser.banner=new_banner
+
+    def set_banner
+      return if @user_specified_banner
+      return unless @banner_stale
+
+      new_banner = base_usage_line
+      new_banner += " [options]" if (@commands.empty? or parent_opts.nil?) and accept_options?
+      new_banner += " command [command options and args...]" unless @commands.empty?
+
+      if @commands.empty? and !@args.empty?
+        new_banner += " "
+        new_banner += @args.map { |arg|
+          if @arg_options[arg].include? :any
+            "[#{arg.to_s}...]"
+          elsif @arg_options[arg].include? :optional
+            "[#{arg.to_s}]"
+          elsif @arg_options[arg].include? :many
+            "#{arg.to_s}..."
+          else
+            arg.to_s
+          end
+        }.join(' ')
       end
+
+      new_banner += "\n\n#{@description}" if @description
+      new_banner += "\n\nv#{@version}" if @version
+
+      new_banner += "\n\nOptions:"
+      @option_parser.banner=new_banner
+      @banner_stale = false
     end
 
     def option_names(*opts_on_args,&block)
@@ -586,10 +1021,16 @@ module Methadone
         else
           nil
         end
-      }.reject(&:nil?)
+      }.reject(&:nil?).map {|name| [name,name.to_s]}.flatten
     end
 
     STRINGS_ONLY = lambda { |o| o.kind_of?(::String) }
 
   end
+
+  InvalidProvider = Class.new(TypeError)
+
+  OptionParser::OptionConflict = Class.new(OptionParser::ParseError)
+  OptionParser::MissingRequiredOption = Class.new(OptionParser::ParseError)
+
 end

--- a/templates/multicommand/bin/executable.erb
+++ b/templates/multicommand/bin/executable.erb
@@ -7,10 +7,15 @@ $LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), '../lib'))
 require 'optparse'
 require 'methadone'
 require '<%= require_file %>'
+require '<%= gemname %>/commands'
 
 class App
   include Methadone::Main
   include Methadone::CLILogging
+
+<% commands.each do |cmd| -%>
+  command "<%= cmd %>" => <%= module_name %>::Commands::<%= titlify(normalize_command(cmd)) %>
+<% end -%>
 
   main do # Add args you want: |like,so|
     # your program code here
@@ -34,14 +39,14 @@ class App
   # Or, just call OptionParser methods on opts
   #
   # Require an argument
-  # arg :some_arg 
+  # arg :some_arg
   #
   # # Make an argument optional
   # arg :optional_arg, :optional
 
   version <%= module_name %>::VERSION
 
-  use_log_level_option :toggle_debug_on_signal => 'USR1'
+  use_log_level_option
 
   go!
 end

--- a/templates/multicommand/lib/command.rb.erb
+++ b/templates/multicommand/lib/command.rb.erb
@@ -1,0 +1,40 @@
+require 'optparse'
+require 'methadone'
+
+module <%= module_name %>
+  module Commands
+    class <%= titlify(normalize_command(cmd)) %>
+      include Methadone::Main
+      include Methadone::CLILogging
+
+      main do # Add args you want: |like,so|
+        # your program code here
+        # You can access CLI options via
+        # the options Hash
+      end
+
+      # supplemental methods here
+
+      # Declare command-line interface here
+
+      # description "one line description of your app"
+      description "provides command '<%= cmd -%>'"
+
+      # Accept flags via:
+      # on("--flag VAL","Some flag")
+      # options[flag] will contain VAL
+      #
+      # Specify switches via:
+      # on("--[no-]switch","Some switch")
+      #
+      # Or, just call OptionParser methods on opts
+      #
+      # Require an argument
+      # arg :some_arg
+      #
+      # # Make an argument optional
+      # arg :optional_arg, :optional
+    end
+  end
+end
+

--- a/templates/multicommand/lib/commands.rb.erb
+++ b/templates/multicommand/lib/commands.rb.erb
@@ -1,0 +1,7 @@
+Dir[File.dirname(__FILE__) + '/commands/*.rb'].each {|file| require file }
+
+module <%= module_name %>
+  module Commands
+  end
+end
+

--- a/test/test_exit_now.rb
+++ b/test/test_exit_now.rb
@@ -21,7 +21,7 @@ class TestExitNow < BaseTest
     }
   end
 
-  test_that "exit_now without an exit code uses 1 as the exti code" do
+  test_that "exit_now without an exit code uses 1 as the exit code" do
     Given {
       @message = any_string
     }

--- a/test/test_multi.rb
+++ b/test/test_multi.rb
@@ -1,0 +1,405 @@
+require 'base_test'
+require 'methadone'
+require 'stringio'
+require 'fileutils'
+
+class TestMulti < BaseTest
+  include Methadone::Main
+  include Methadone::CLILogging
+
+  module Commands
+    class Walk
+      include Methadone::Main
+      include Methadone::CLILogging
+      main do |distance|
+        puts "walk called"
+      end
+      options[:direction] = 0
+      description "moves slowly for a given distance"
+      on '-s', '--silly-walk'
+      on '-d', '--direction DIRECTION', Integer, "Compass cardinal direction"
+      arg "distance", "How far to walk"
+
+    end
+    class Run
+      include Methadone::Main
+      include Methadone::CLILogging
+      main do |distance, duty_cycle|
+        puts "run called"
+      end
+      options[:direction] = 0
+      description "moves quickly for a given distance"
+      on '-s', '--silly-walk'
+      on '-d', '--direction DIRECTION', Integer, "Compass cardinal direction"
+      arg "distance", "How far to run"
+      arg "duty_cycle", "Percent of time spent running (default: 100)", :optional
+    end
+    class Greet
+      include Methadone::Main
+
+      options[:lang] = 'es'
+
+      main do
+        msg = case options[:lang]
+        when 'en'
+          'Hello'
+        when 'fr'
+          'Bonjour'
+        when 'es'
+          'Hola'
+        else
+          '????'
+        end
+
+        msg = msg.upcase if options[:yell]
+        puts msg
+      end
+    end
+
+    class Say
+      include Methadone::Main
+      on '--yell', "Be loud", :global
+      command 'greeting' => ::TestMulti::Commands::Greet
+    end
+  end
+
+  def setup
+    @original_argv = ARGV.clone
+    ARGV.clear
+    @old_stdout = $stdout
+    $stdout = StringIO.new
+    @logged = StringIO.new
+    @orig_logger = logger
+    @custom_logger = Logger.new(@logged)
+    change_logger @custom_logger
+
+    @original_home = ENV['HOME']
+    fake_home = '/tmp/fake-home'
+    FileUtils.rm_rf(fake_home)
+    FileUtils.mkdir(fake_home)
+    ENV['HOME'] = fake_home
+  end
+
+  def teardown
+    @commands = nil
+    change_logger @orig_logger
+    set_argv @original_argv
+    ENV.delete('DEBUG')
+    ENV.delete('APP_OPTS')
+    $stdout = @old_stdout
+    ENV['HOME'] = @original_home
+  end
+
+  test_that "commands can be specified" do
+    When {
+      command "walk" => Commands::Walk
+    }
+    Then number_of_commands_should_be(1)
+    Then commands_should_include("walk")
+    Then {
+      provider_for_command("walk").should be Commands::Walk
+    }
+  end
+
+  test_that "command providers must accept go! message" do
+    Given {
+      module Commands
+        class WontWork
+        end
+      end
+    }
+    When {
+      @error = nil
+      begin
+        command "trythis" => Commands::WontWork
+      rescue Exception => error
+        @error = error
+      end
+    }
+    Then number_of_commands_should_be(0)
+    Then {
+      @error.should be_a_kind_of(::Methadone::InvalidProvider)
+    }
+  end
+
+  test_that "command is detected in the arguments" do
+    Given {
+      main do
+      end
+
+      command "walk" => Commands::Walk
+      set_argv %w(walk 10)
+    }
+    When run_go_safely
+    Then {
+      opts.selected_command.should eq('walk')
+    }
+  end
+
+  test_that "command in the arguments causes the right command to be called" do
+    Given app_has_subcommands('walk','run')
+    And {
+      version '1.2.3'
+      set_argv %w(walk 10)
+    }
+    When run_go_safely
+    Then {
+      opts.command_names.should include('walk')
+      opts.command_names.should include('run')
+      $stdout.string.should match(/walk called/)
+    }
+    And number_of_commands_should_be(2)
+  end
+
+  test_that "help is displayed if no command on command line" do
+    Given app_has_subcommands('walk','run')
+    And {
+      @main_called = false
+      main do
+        @main_called = true
+        puts 'main called'
+      end
+    }
+    When run_go_safely
+    Then main_should_not_be_called
+    And help_shown
+    And {
+      assert_logged_at_error("You must specify a command")
+    }
+  end
+
+  test_that "app with subcommands list subcommands in help" do
+    Given app_has_subcommands('walk','run')
+    When {
+      setup_defaults
+      opts.post_setup
+    }
+    Then {
+      opts.to_s.should match /(?m)Commands:\n.*walk: moves slowly/
+      opts.to_s.should match /(?m)Commands:\n.*run:  moves quickly/
+    }
+    And {
+      opts.to_s.should match /Usage:.*command \[command options and args...\]/
+    }
+  end
+
+  test_that "app without subcommands do not list command prefix in help" do
+    Given {
+      main do
+      end
+      on '--switch'
+      on '--flag FOO'
+      arg 'must_have'
+      arg 'optionals', :any
+    }
+    When {
+      setup_defaults
+      opts.post_setup
+    }
+    Then {
+      opts.to_s.should_not match /Commands:/m
+    }
+  end
+
+  test_that "subcommand can get its own help" do
+    Given app_has_subcommands('walk','run')
+    And {
+      version '1.2.3'
+      set_argv %w(walk -h)
+    }
+    When run_go_safely
+    Then {
+      $stdout.string.should match /Usage: #{::File.basename($0)} walk \[options\] distance/
+    }
+  end
+
+  someday_test_that "rc_file can specify defaults for each subcommand" do
+  end
+
+  test_that "subcommand help shows global options from parent" do
+    Given app_has_subcommands('walk','run')
+    And {
+      version '1.2.3'
+      set_argv %w(walk -h)
+      on '-w','--wow', :global, "This is a global option"
+    }
+    When run_go_safely
+    Then {
+      $stdout.string.should match /Usage: #{::File.basename($0)} \[global options\] walk \[options\] distance/
+      $stdout.string.should match /(?m)Global options:\n.*-w, --wow *This is a global option/
+      $stdout.string.should_not match /(?m)Global options:\n.*-v, --version/
+    }
+  end
+
+
+  test_that "subcommands have access to global options" do
+    Given app_has_subcommands('greet')
+    And {
+      options[:lang] = 'en'
+      on '-l', '--lang LANG','Set the language', :global
+      set_argv %w(-l fr greet)
+    }
+    When run_go_safely
+    Then {
+      $stdout.string.should match /Bonjour/
+      $stdout.string.should_not match /Hello/
+      $stdout.string.should_not match /Hola/
+      $stdout.string.should_not match /\?\?\?\?/
+    }
+  end
+
+  test_that "subcommands of subcommands help shows parents global options" do
+    Given app_is_three_layers_deep_with_middle_layer_having_global_options
+    And {
+      set_argv %w(say --yell greeting)
+    }
+    When run_go_safely
+    Then {
+      cmd_opts = opts.commands['say'].opts.commands['greeting'].opts
+      cmd_opts.to_s.should match /say \[options [f]or say\] greeting/
+      cmd_opts.to_s.should match /(?m)Options [f]or say:\n.*--yell *Be loud/
+      cmd_opts.to_s.should_not match /\[global options\]/
+      cmd_opts.to_s.should_not match /Global options:/
+      $stdout.string.should match /HOLA/
+    }
+  end
+
+  test_that "subcommands of subcommands help shows parents global options and base global options" do
+    Given app_is_three_layers_deep_with_middle_layer_having_global_options
+    And {
+      on '-l', '--lang LANG','Set the language', :global
+      set_argv %w(-l en say --yell greeting)
+    }
+    When run_go_safely
+    Then {
+      cmd_opts = opts.commands['say'].opts.commands['greeting'].opts
+      cmd_opts.to_s.should match /\[global options\] say \[options [f]or say\] greeting/
+      cmd_opts.to_s.should match /(?m)Options [f]or say:\n.*--yell *Be loud/
+      cmd_opts.to_s.should match /(?m)Global options:\n.*-l, --lang LANG *Set the language/
+      $stdout.string.should match /HELLO/
+    }
+  end
+
+private
+
+  def commands_should_include(cmd)
+    proc { opts.commands.keys.should include(cmd) }
+  end
+
+  def number_of_commands_should_be(num)
+    proc { opts.commands.keys.length.should be(num)}
+  end
+
+  def provider_for_command(cmd)
+    opts.commands[cmd]
+  end
+
+  def app_has_subcommands(*args)
+    proc {
+      args.each do |cmd|
+        command cmd => get_const("TestMulti::Commands::#{cmd.capitalize}")
+      end
+    }
+  end
+
+  def app_is_three_layers_deep_with_middle_layer_having_global_options
+    proc {
+      # Requires special resetting to ensure proper behaviour
+      reset!
+      command 'say' => get_const("TestMulti::Commands::Say")
+      opts.commands['say'].instance_variable_get(:@options).delete_if {|k,v| true}
+      opts.commands['say'].opts.commands['greeting'].instance_variable_get(:@options).delete_if {|k,v| true}
+      opts.commands['say'].opts.commands['greeting'].instance_variable_get(:@options)[:lang] = 'es'
+    }
+  end
+
+
+  def help_shown
+    proc {assert $stdout.string.include?(opts.to_s),"Expected #{$stdout.string} to contain #{opts.to_s}"}
+  end
+
+  def app_to_use_rc_file
+    lambda {
+      @switch = nil
+      @flag = nil
+      @args = nil
+      main do |*args|
+        @switch = options[:switch]
+        @flag = options[:flag]
+        @args = args
+      end
+
+      defaults_from_config_file '.my_app.rc'
+
+      on('--switch','Some Switch')
+      on('--flag FOO','Some Flag')
+    }
+  end
+
+  def main_that_exits(exit_status)
+    proc { main { exit_status } }
+  end
+
+  def app_to_use_environment
+    lambda {
+      @switch = nil
+      @flag = nil
+      @args = nil
+      main do |*args|
+        @switch = options[:switch]
+        @flag = options[:flag]
+        @args = args
+      end
+
+      defaults_from_env_var 'APP_OPTS'
+
+      on('--switch','Some Switch')
+      on('--flag FOO','Some Flag')
+    }
+  end
+
+  def main_should_not_be_called
+    Proc.new { assert !@main_called,"Main block was called?!" }
+  end
+
+  def main_shouldve_been_called
+    Proc.new { assert @main_called,"Main block wasn't called?!" }
+  end
+
+  def run_go_safely
+    Proc.new { safe_go! }
+  end
+
+  # Calls go!, but traps the exit
+  def safe_go!
+    go!
+  rescue SystemExit
+  end
+
+  def run_go!; proc { go! }; end
+
+  def assert_logged_at_error(expected_message)
+    @logged.string.should include expected_message
+  end
+
+  def assert_exits(exit_code,message='',&block)
+    block.call
+    fail "Expected an exit of #{exit_code}, but we didn't even exit!"
+  rescue SystemExit => ex
+    assert_equal exit_code,ex.status,@logged.string
+  end
+
+  def set_argv(args)
+    ARGV.clear
+    args.each { |arg| ARGV << arg }
+  end
+
+  def get_const(class_name)
+    unless /\A(?:::)?([A-Z]\w*(?:::[A-Z]\w*)*)\z/ =~ class_name
+      raise NameError, "#{class_name.inspect} is not a valid constant name!"
+    end
+
+    Object.module_eval("::#{$1}", __FILE__, __LINE__)
+  end
+
+end


### PR DESCRIPTION
Includes all the relevant changes cleaned and rebased to v1.9.1 from
https://github.com/dennisjbell/methadone-clinic . Dividing this into meaningful atomic commits was not feasible. Temporarily, we are maintaining this as our own fork at https://github.com/enemy/methadone-rehab.

Without fully integrated subcommand support, users are reduced to
rolling their own and implementing large if-else trees as can be seen in
https://jonbake.com/blog/a-walk-through-of-creating-a-command-line-application-in-ruby/
and
https://github.com/jonmbake/command-line-favs/blob/master/lib/fav.rb

List of Changes:
- Subcommand support:
  - Allow multiple nested Methadone::Main classes mapped together with the command method.
  - Methadone::Main classes can be nested infinitely to have sub-subcommands.
  - https://github.com/dennisjbell/methadone-clinic/blob/master/lib/methadone/main.rb#L72-L116
  - Allows for commands like git init or git remote add to be implemented in a structured manner.
- Allow options to mutually exclude each other.
- Allow options to depend on having other options used as well.
- Allocation of arguments are now as-needed, providing values to arguments that need an argument before filling the first greedy argument with the rest of the available values.
- ARGV retains any unused options or arguments.
- version method allows for shorthand options of :basic and :terse.
- optional parameter to add lib folder to the $LOAD_PATH of the generated project.

List of Contributors:
@juhazi @matti