### PR TITLE
Remove duplicate rake dependency

### DIFF
--- a/bin/methadone
+++ b/bin/methadone
@@ -83,7 +83,6 @@ main do |app_name|
   add_to_file gemspec, [
     "  #{gem_variable}.add_development_dependency('rdoc')",
     "  #{gem_variable}.add_development_dependency('aruba')",
-    "  #{gem_variable}.add_development_dependency('rake')",
     "  #{gem_variable}.add_dependency('methadone', '~> #{Methadone::VERSION}')",
   ], :before => /^end\s*$/
   ruby_major,ruby_minor,ruby_patch = RUBY_VERSION.split(/\./).map(&:to_i)

--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -37,7 +37,7 @@ Feature: Bootstrap a new command-line app
     And the file "tmp/newgem/.gitignore" should match /.DS_Store/
     And the file "tmp/newgem/newgem.gemspec" should match /add_development_dependency\('aruba'/
     And the file "tmp/newgem/newgem.gemspec" should match /add_development_dependency\('rdoc'/
-    And the file "tmp/newgem/newgem.gemspec" should match /add_development_dependency\('rake'/
+    And the file "tmp/newgem/newgem.gemspec" should match /add_development_dependency "rake"/
     And the file "tmp/newgem/newgem.gemspec" should match /add_dependency\('methadone'/
     And the file "tmp/newgem/newgem.gemspec" should include "test-unit" if needed
     And the file "tmp/newgem/newgem.gemspec" should use the same block variable throughout


### PR DESCRIPTION
Hi Dave,

Bundler already includes `rake` so you get the following warning after bootstrapping and remove ing all the `TODO`s from the gemspec:

```
You have one or more invalid gemspecs that need to be fixed.
The gemspec at /Users/max/Dropbox/work/src/github.com/mbigras/devify/devify.gemspec is not valid. Please fix this gemspec.
The validation error was 'duplicate dependency on rake (>= 0, development), (~> 10.0) use:
    add_development_dependency 'rake', '>= 0', '~> 10.0'
```

Seems like since we're using bundler's skeleton anyways we should use their version of rake?

Happy new year 🎉
