### PR TITLE
declare module explicitly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin/cukedoc
 methadone.wiki
 tut
 .idea
+Session.vim

--- a/lib/methadone/test/base_integration_test.rb
+++ b/lib/methadone/test/base_integration_test.rb
@@ -9,6 +9,8 @@ require_relative "integration_test_assertions"
 # Clean test should be setting this
 $FOR_TESTING_ONLY_SKIP_STDERR = false
 
+module Methadone
+end
 class Methadone::BaseIntegrationTest < Test::Unit::TestCase
   include FileUtils
   include Methadone::IntegrationTestAssertions


### PR DESCRIPTION
Since this file is required all by itself, especially when bootstrapping
an app, we need to make sure the `Methadone` module is declared.

Fixes #123 