### PR TITLE
declare module before use.  For real this time.

### DIFF
--- a/lib/methadone/test/integration_test_assertions.rb
+++ b/lib/methadone/test/integration_test_assertions.rb
@@ -1,3 +1,5 @@
+module Methadone
+end
 module Methadone::IntegrationTestAssertions
   # Assert that a file's contents contains one or more regexps
   #


### PR DESCRIPTION
# Problem

integration test helpers uses the `Methodone` module without explicitly declaring it and depending on how files get required, things don't work.  See #126 

# Solution

move module declaration.

Fixes #126 