### PR TITLE
Snake vs. Kabob case in gem name

### DIFF
--- a/bin/optparse_plus
+++ b/bin/optparse_plus
@@ -90,7 +90,7 @@ main do |app_name|
 
   add_to_file gemspec, [
     "  #{gem_variable}.add_development_dependency('rdoc')",
-    "  #{gem_variable}.add_dependency('optparse_plus', '~> #{OptparsePlus::VERSION}')",
+    "  #{gem_variable}.add_dependency('optparse-plus', '~> #{OptparsePlus::VERSION}')",
   ], :before => /^end\s*$/
   ruby_major,ruby_minor,ruby_patch = RUBY_VERSION.split(/\./).map(&:to_i)
 

--- a/test/integration/test_bootstrap.rb
+++ b/test/integration/test_bootstrap.rb
@@ -38,6 +38,7 @@ class TestBootstrap < BaseIntegrationTest
       gemspec = File.read("newgem/newgem.gemspec")
       refute_match(/TODO/,gemspec)
       refute_match(/FIXME/,gemspec)
+      refute_match(/optparse_plus/,gemspec)
     }
   end
 


### PR DESCRIPTION
Fix for this [issue](https://github.com/davetron5000/optparse-plus/issues/131). The testing update isn't very specific to this issue. Feel free to ask for or implement changes there.

Thanks for the library, I am really liking it. 